### PR TITLE
Add support for TextSpans

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -5,3 +5,15 @@ Text('some text')
   .textColor(Colors.green)
   .alignment(Alignment.center)
 ```
+
+For text with multiple styles:
+```dart
+Text.rich(TextSpan(
+  text: 'Some text',
+  children: [
+    TextSpan(text: ' and some more text')
+        .bold()
+        .textColor(Colors.yellow),
+  ],
+))
+```

--- a/lib/src/text_span.dart
+++ b/lib/src/text_span.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/widgets.dart';
+
+extension on TextSpan {
+  TextSpan copyWith({
+    TextStyle style,
+    GestureRecognizer recognizer,
+    String semanticsLabel,
+  }) =>
+      TextSpan(
+        text: this.text,
+        children: this.children,
+        style: style ?? this.style,
+        recognizer: recognizer ?? this.recognizer,
+        semanticsLabel: semanticsLabel ?? this.semanticsLabel,
+      );
+
+  TextSpan bold() => this.copyWith(
+        style: (this.style ?? TextStyle()).copyWith(
+          fontWeight: FontWeight.bold,
+        ),
+      );
+
+  TextSpan italic() => this.copyWith(
+        style: (this.style ?? TextStyle()).copyWith(
+          fontStyle: FontStyle.italic,
+        ),
+      );
+
+  TextSpan fontWeight(FontWeight fontWeight) => this.copyWith(
+        style: (this.style ?? TextStyle()).copyWith(
+          fontWeight: fontWeight,
+        ),
+      );
+
+  TextSpan fontSize(double size) => this.copyWith(
+        style: (this.style ?? TextStyle()).copyWith(
+          fontSize: size,
+        ),
+      );
+
+  TextSpan fontFamily(String font) => this.copyWith(
+        style: (this.style ?? TextStyle()).copyWith(
+          fontFamily: font,
+        ),
+      );
+
+  TextSpan letterSpacing(double space) => this.copyWith(
+        style: (this.style ?? TextStyle()).copyWith(
+          letterSpacing: space,
+        ),
+      );
+
+  TextSpan wordSpacing(double space) => this.copyWith(
+        style: (this.style ?? TextStyle()).copyWith(
+          wordSpacing: space,
+        ),
+      );
+
+  TextSpan textShadow({
+    Color color = const Color(0x33000000),
+    double blurRadius = 0.0,
+    Offset offset = Offset.zero,
+  }) =>
+      this.copyWith(
+        style: (this.style ?? TextStyle()).copyWith(
+          shadows: [
+            Shadow(
+              color: color,
+              blurRadius: blurRadius,
+              offset: offset,
+            ),
+          ],
+        ),
+      );
+
+  TextSpan textColor(Color color) => this.copyWith(
+        style: (this.style ?? TextStyle()).copyWith(
+          color: color,
+        ),
+      );
+
+  TextSpan textBaseline(TextBaseline textBaseline) => this.copyWith(
+        style: (this.style ?? TextStyle()).copyWith(
+          textBaseline: textBaseline,
+        ),
+      );
+}

--- a/lib/styled_widget.dart
+++ b/lib/styled_widget.dart
@@ -7,4 +7,5 @@ A styled widget should have its own respective file
 
 export 'src/widget.dart';
 export 'src/text.dart';
+export 'src/text_span.dart';
 export 'src/icon.dart';


### PR DESCRIPTION
Fixes issue #12.

Experimented locally with this code which rendered the expected result:
```dart
Text.rich(TextSpan(
  text: 'Some text',
  children: [
    TextSpan(text: ' and some more text')
        .bold()
        .textColor(Colors.yellow),
  ],
)),
```
Also, much is copied from the `Text` extension, since they both use `TextStyle`.
However, `Text` has `direction/alignment` which `TextSpan` does _not_.