### PR TITLE
Fix issues #51

### DIFF
--- a/lib/src/extensions/list_extension.dart
+++ b/lib/src/extensions/list_extension.dart
@@ -52,7 +52,7 @@ extension StyledList<E> on List<Widget> {
     AlignmentGeometry alignment = AlignmentDirectional.topStart,
     TextDirection textDirection,
     StackFit fit = StackFit.loose,
-    Overflow overflow = Overflow.clip,
+    Clip clipBehavior = Clip.hardEdge,
     List<Widget> children = const <Widget>[],
   }) =>
       Stack(
@@ -60,7 +60,7 @@ extension StyledList<E> on List<Widget> {
         alignment: alignment,
         textDirection: textDirection,
         fit: fit,
-        overflow: overflow,
+        clipBehavior: clipBehavior,
         children: this,
       );
 }


### PR DESCRIPTION
overflow property has been removed from Stack in latest master, dev channel
and it's will also remove in future.

https://api.flutter.dev/flutter/widgets/Stack/overflow.html
*This overrides clipBehavior for now due to a staged roll out without breaking Google. We will remove it and only use clipBehavior soon*