### PR TITLE
Support for directional widgets (padding, positioned, borderRadius)

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -127,7 +127,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.2.2"
+    version: "0.3.0"
   term_glyph:
     dependency: transitive
     description:

--- a/lib/src/extensions/widget_extension.dart
+++ b/lib/src/extensions/widget_extension.dart
@@ -72,6 +72,43 @@ extension StyledWidget on Widget {
               child: this,
             );
 
+  Widget paddingDirectional({
+    double? all,
+    double? horizontal,
+    double? vertical,
+    double? top,
+    double? bottom,
+    double? start,
+    double? end,
+    bool animate = false,
+  }) =>
+      animate
+          ? Builder(
+              builder: (BuildContext context) {
+                _StyledAnimatedModel animation = this._getAnimation(context);
+                return AnimatedPadding(
+                  child: this,
+                  padding: EdgeInsetsDirectional.only(
+                    top: top ?? vertical ?? all ?? 0.0,
+                    bottom: bottom ?? vertical ?? all ?? 0.0,
+                    start: start ?? horizontal ?? all ?? 0.0,
+                    end: end ?? horizontal ?? all ?? 0.0,
+                  ),
+                  duration: animation.duration,
+                  curve: animation.curve,
+                );
+              },
+            )
+          : Padding(
+              padding: EdgeInsetsDirectional.only(
+                top: top ?? vertical ?? all ?? 0.0,
+                bottom: bottom ?? vertical ?? all ?? 0.0,
+                start: start ?? horizontal ?? all ?? 0.0,
+                end: end ?? horizontal ?? all ?? 0.0,
+              ),
+              child: this,
+            );
+
   Widget opacity(
     double opacity, {
     bool animate = false,
@@ -339,6 +376,39 @@ extension StyledWidget on Widget {
         topRight: Radius.circular(topRight ?? all ?? 0.0),
         bottomLeft: Radius.circular(bottomLeft ?? all ?? 0.0),
         bottomRight: Radius.circular(bottomRight ?? all ?? 0.0),
+      ),
+    );
+    return animate
+        ? _StyledAnimatedBuilder(
+            builder: (animation) {
+              return _AnimatedDecorationBox(
+                child: this,
+                decoration: decoration,
+                duration: animation.duration,
+                curve: animation.curve,
+              );
+            },
+          )
+        : DecoratedBox(
+            child: this,
+            decoration: decoration,
+          );
+  }
+
+  Widget borderRadiusDirectional({
+    double? all,
+    double? topStart,
+    double? topEnd,
+    double? bottomStart,
+    double? bottomEnd,
+    bool animate = false,
+  }) {
+    BoxDecoration decoration = BoxDecoration(
+      borderRadius: BorderRadiusDirectional.only(
+        topStart: Radius.circular(topStart ?? all ?? 0.0),
+        topEnd: Radius.circular(topEnd ?? all ?? 0.0),
+        bottomStart: Radius.circular(bottomStart ?? all ?? 0.0),
+        bottomEnd: Radius.circular(bottomEnd ?? all ?? 0.0),
       ),
     );
     return animate
@@ -931,6 +1001,39 @@ extension StyledWidget on Widget {
               left: left,
               top: top,
               right: right,
+              bottom: bottom,
+              width: width,
+              height: height,
+            );
+
+  Widget positionedDirectional({
+    double? start,
+    double? end,
+    double? top,
+    double? bottom,
+    double? width,
+    double? height,
+    bool animate = false,
+  }) =>
+      animate
+          ? _StyledAnimatedBuilder(builder: (animation) {
+              return AnimatedPositionedDirectional(
+                child: this,
+                duration: animation.duration,
+                curve: animation.curve,
+                start: start,
+                end: end,
+                top: top,
+                bottom: bottom,
+                width: width,
+                height: height,
+              );
+            })
+          : PositionedDirectional(
+              child: this,
+              start: start,
+              end: end,
+              top: top,
               bottom: bottom,
               width: width,
               height: height,

--- a/lib/src/extensions/widget_extension.dart
+++ b/lib/src/extensions/widget_extension.dart
@@ -1197,4 +1197,6 @@ extension StyledWidget on Widget {
         semanticContainer: semanticContainer,
         child: this,
       );
+
+  Widget safeArea() => SafeArea(child: this);
 }


### PR DESCRIPTION
This PR should solve this issue #59.
I could make them in one single method with all the method args  for each, instead of having two methods:
- `padding`, `paddingDirectional`
- `positioned`, `positionedDirectional`
- `borderRadius`, `borderRadiusDirectional`

But this would confuse the developer which arg to use if we made a method that takes all these args:
- start
- end
- top
- bottom
- left
- right
- horizontal
- vertical
- all

I think what I did is much more convenient to have those methods separated, like Flutter does:
- `EdgeInsets`, `EdgeInsetsDirectional`
- `Positioned`, `PositionedDirectional`
- `BorderRadius`, `BorderRadiusDirectional`