### PR TITLE
Add Material & MouseRegion extention

### DIFF
--- a/lib/src/extensions/widget_extension.dart
+++ b/lib/src/extensions/widget_extension.dart
@@ -1412,4 +1412,22 @@ extension StyledWidget on Widget {
         animationDuration: animationDuration,
         child: this,
       );
+
+  Widget mouseRegion({
+    Key? key,
+    void Function(PointerEnterEvent)? onEnter,
+    void Function(PointerExitEvent)? onExit,
+    void Function(PointerHoverEvent)? onHover,
+    MouseCursor cursor = MouseCursor.defer,
+    bool opaque = true,
+  }) =>
+      MouseRegion(
+        key: key,
+        onEnter: onEnter,
+        onExit: onExit,
+        onHover: onHover,
+        cursor: cursor,
+        opaque: opaque,
+        child: this,
+      );
 }

--- a/lib/src/extensions/widget_extension.dart
+++ b/lib/src/extensions/widget_extension.dart
@@ -1384,4 +1384,32 @@ extension StyledWidget on Widget {
         maxHeight: maxHeight,
         child: this,
       );
+
+  Widget material({
+    Key? key,
+    MaterialType type = MaterialType.canvas,
+    double elevation = 0.0,
+    Color? color,
+    Color? shadowColor,
+    TextStyle? textStyle,
+    BorderRadiusGeometry? borderRadius,
+    ShapeBorder? shape,
+    bool borderOnForeground = true,
+    Clip clipBehavior = Clip.none,
+    Duration animationDuration = kThemeChangeDuration,
+  }) =>
+      Material(
+        key: key,
+        type: type,
+        elevation: elevation,
+        color: color,
+        shadowColor: shadowColor,
+        textStyle: textStyle,
+        borderRadius: borderRadius,
+        shape: shape,
+        borderOnForeground: borderOnForeground,
+        clipBehavior: clipBehavior,
+        animationDuration: animationDuration,
+        child: this,
+      );
 }


### PR DESCRIPTION
The use case for `.material` is mostly when you just want to wrap something in `Material` so that widgets that require material parents work correctly. I kinda understand that maybe this use case doesn't warrant adding it to this repository so I can revert it if you want :).