### PR TITLE
move `lint` as dev dependency

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:lint/analysis_options.yaml
+include: package:lint/strict.yaml
 
 linter:
   rules:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,51 +5,50 @@ packages:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      url: "https://pub.dev"
     source: hosted
-    version: "2.8.2"
+    version: "2.10.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
+    version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.dartlang.org"
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.17.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      url: "https://pub.dartlang.org"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -60,34 +59,46 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  lint:
+  js:
     dependency: transitive
     description:
-      name: lint
-      url: "https://pub.dartlang.org"
+      name: js
+      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.5.3"
+    version: "0.6.5"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.13"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -97,64 +108,64 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.1"
+    version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   styled_widget:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "0.4.0+3"
+    version: "0.4.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.3"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
+    version: "0.4.16"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.4"
 sdks:
-  dart: ">=2.14.0 <3.0.0"
+  dart: ">=2.18.0 <3.0.0"

--- a/lib/src/animated_icon.dart
+++ b/lib/src/animated_icon.dart
@@ -2,13 +2,18 @@ part of '../styled_widget.dart';
 
 // TODO: why extend icon
 class _StyledAnimatedIconContainer extends Icon {
+  @override
   final IconData? icon;
+  @override
   final double? size;
+  @override
   final Color? color;
+  @override
   final String? semanticLabel;
+  @override
   final TextDirection? textDirection;
 
-  _StyledAnimatedIconContainer(
+  const _StyledAnimatedIconContainer(
     this.icon, {
     this.color,
     this.semanticLabel,
@@ -24,7 +29,7 @@ class _StyledAnimatedIconContainer extends Icon {
 
   @override
   Widget build(BuildContext context) {
-    _StyledAnimatedModel? animation =
+    final _StyledAnimatedModel? animation =
         _StyledInheritedAnimation.of(context)?.animation;
     if (animation == null) {
       return super.build(context);
@@ -47,7 +52,7 @@ class _AnimatedIcon extends ImplicitlyAnimatedWidget {
   /// Creates a container that animates its parameters implicitly.
   ///
   /// The [curve] and [duration] arguments must not be null.
-  _AnimatedIcon(
+  const _AnimatedIcon(
     this.icon, {
     Key? key,
     this.color,
@@ -70,12 +75,6 @@ class _AnimatedIcon extends ImplicitlyAnimatedWidget {
 
   @override
   _AnimatedIconState createState() => _AnimatedIconState();
-
-  @override
-  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
-    // TODO: debug
-  }
 }
 
 class _AnimatedIconState extends AnimatedWidgetBaseState<_AnimatedIcon> {

--- a/lib/src/animated_text.dart
+++ b/lib/src/animated_text.dart
@@ -45,7 +45,8 @@ class _StyledAnimatedTextContainer extends Text {
 
   @override
   Widget build(BuildContext context) {
-    _StyledAnimatedModel? animation = _StyledInheritedAnimation.of(context)?.animation;
+    _StyledAnimatedModel? animation =
+        _StyledInheritedAnimation.of(context)?.animation;
     if (animation == null) {
       return super.build(context);
     }
@@ -130,18 +131,20 @@ class _AnimatedTextState extends AnimatedWidgetBaseState<_AnimatedText> {
 
   @override
   void forEachTween(TweenVisitor<dynamic> visitor) {
-    _textScaleFactor =
-        visitor(_textScaleFactor, widget.textScaleFactor, (dynamic value) => Tween<double>(begin: value as double))
-            as Tween<double>?;
-    _fontSize = visitor(_fontSize, widget.style?.fontSize, (dynamic value) => Tween<double>(begin: value as double))
+    _textScaleFactor = visitor(_textScaleFactor, widget.textScaleFactor,
+            (dynamic value) => Tween<double>(begin: value as double))
         as Tween<double>?;
-    _letterSpacing =
-        visitor(_letterSpacing, widget.style?.letterSpacing, (dynamic value) => Tween<double>(begin: value as double))
-            as Tween<double>?;
-    _wordSpacing =
-        visitor(_wordSpacing, widget.style?.wordSpacing, (dynamic value) => Tween<double>(begin: value as double))
-            as Tween<double>?;
-    _height = visitor(_height, widget.style?.height, (dynamic value) => Tween<double>(begin: value as double))
+    _fontSize = visitor(_fontSize, widget.style?.fontSize,
+            (dynamic value) => Tween<double>(begin: value as double))
+        as Tween<double>?;
+    _letterSpacing = visitor(_letterSpacing, widget.style?.letterSpacing,
+            (dynamic value) => Tween<double>(begin: value as double))
+        as Tween<double>?;
+    _wordSpacing = visitor(_wordSpacing, widget.style?.wordSpacing,
+            (dynamic value) => Tween<double>(begin: value as double))
+        as Tween<double>?;
+    _height = visitor(_height, widget.style?.height,
+            (dynamic value) => Tween<double>(begin: value as double))
         as Tween<double>?;
     _decorationThickness = visitor(
       _decorationThickness,

--- a/lib/src/animated_text.dart
+++ b/lib/src/animated_text.dart
@@ -2,20 +2,32 @@ part of '../styled_widget.dart';
 
 // TODO: why extend text
 class _StyledAnimatedTextContainer extends Text {
+  @override
   final String data;
+  @override
   final TextStyle? style;
+  @override
   final StrutStyle? strutStyle;
+  @override
   final TextAlign? textAlign;
+  @override
   final TextDirection? textDirection;
+  @override
   final Locale? locale;
+  @override
   final bool? softWrap;
+  @override
   final TextOverflow? overflow;
+  @override
   final double? textScaleFactor;
+  @override
   final int? maxLines;
+  @override
   final String? semanticsLabel;
+  @override
   final TextWidthBasis? textWidthBasis;
 
-  _StyledAnimatedTextContainer(
+  const _StyledAnimatedTextContainer(
     this.data, {
     this.locale,
     this.maxLines,
@@ -45,7 +57,7 @@ class _StyledAnimatedTextContainer extends Text {
 
   @override
   Widget build(BuildContext context) {
-    _StyledAnimatedModel? animation =
+    final _StyledAnimatedModel? animation =
         _StyledInheritedAnimation.of(context)?.animation;
     if (animation == null) {
       return super.build(context);
@@ -75,7 +87,7 @@ class _AnimatedText extends ImplicitlyAnimatedWidget {
   /// Creates a container that animates its parameters implicitly.
   ///
   /// The [curve] and [duration] arguments must not be null.
-  _AnimatedText(
+  const _AnimatedText(
     this.data, {
     Key? key,
     this.locale,
@@ -109,12 +121,6 @@ class _AnimatedText extends ImplicitlyAnimatedWidget {
 
   @override
   _AnimatedTextState createState() => _AnimatedTextState();
-
-  @override
-  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
-    // TODO: denug variables
-  }
 }
 
 class _AnimatedTextState extends AnimatedWidgetBaseState<_AnimatedText> {
@@ -131,21 +137,31 @@ class _AnimatedTextState extends AnimatedWidgetBaseState<_AnimatedText> {
 
   @override
   void forEachTween(TweenVisitor<dynamic> visitor) {
-    _textScaleFactor = visitor(_textScaleFactor, widget.textScaleFactor,
-            (dynamic value) => Tween<double>(begin: value as double))
-        as Tween<double>?;
-    _fontSize = visitor(_fontSize, widget.style?.fontSize,
-            (dynamic value) => Tween<double>(begin: value as double))
-        as Tween<double>?;
-    _letterSpacing = visitor(_letterSpacing, widget.style?.letterSpacing,
-            (dynamic value) => Tween<double>(begin: value as double))
-        as Tween<double>?;
-    _wordSpacing = visitor(_wordSpacing, widget.style?.wordSpacing,
-            (dynamic value) => Tween<double>(begin: value as double))
-        as Tween<double>?;
-    _height = visitor(_height, widget.style?.height,
-            (dynamic value) => Tween<double>(begin: value as double))
-        as Tween<double>?;
+    _textScaleFactor = visitor(
+      _textScaleFactor,
+      widget.textScaleFactor,
+      (dynamic value) => Tween<double>(begin: value as double),
+    ) as Tween<double>?;
+    _fontSize = visitor(
+      _fontSize,
+      widget.style?.fontSize,
+      (dynamic value) => Tween<double>(begin: value as double),
+    ) as Tween<double>?;
+    _letterSpacing = visitor(
+      _letterSpacing,
+      widget.style?.letterSpacing,
+      (dynamic value) => Tween<double>(begin: value as double),
+    ) as Tween<double>?;
+    _wordSpacing = visitor(
+      _wordSpacing,
+      widget.style?.wordSpacing,
+      (dynamic value) => Tween<double>(begin: value as double),
+    ) as Tween<double>?;
+    _height = visitor(
+      _height,
+      widget.style?.height,
+      (dynamic value) => Tween<double>(begin: value as double),
+    ) as Tween<double>?;
     _decorationThickness = visitor(
       _decorationThickness,
       widget.style?.decorationThickness,

--- a/lib/src/animated_widget.dart
+++ b/lib/src/animated_widget.dart
@@ -12,8 +12,11 @@ class _StyledAnimatedModel {
 class _StyledInheritedAnimation extends InheritedWidget {
   final _StyledAnimatedModel? animation;
 
-  _StyledInheritedAnimation({Key? key, this.animation, required Widget child})
-      : super(key: key, child: child);
+  const _StyledInheritedAnimation({
+    Key? key,
+    this.animation,
+    required Widget child,
+  }) : super(key: key, child: child);
 
   @override
   bool updateShouldNotify(_StyledInheritedAnimation oldAnimation) =>
@@ -25,13 +28,14 @@ class _StyledInheritedAnimation extends InheritedWidget {
 }
 
 class _StyledAnimatedBuilder extends StatelessWidget {
-  _StyledAnimatedBuilder({Key? key, required this.builder}) : super(key: key);
+  const _StyledAnimatedBuilder({Key? key, required this.builder})
+      : super(key: key);
 
   final Widget Function(_StyledAnimatedModel) builder;
 
   @override
   Widget build(BuildContext context) {
-    _StyledAnimatedModel? animation =
+    final _StyledAnimatedModel? animation =
         _StyledInheritedAnimation.of(context)?.animation;
     assert(
       animation != null,
@@ -85,7 +89,8 @@ class _AnimatedDecorationBox extends ImplicitlyAnimatedWidget {
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(
-        DiagnosticsProperty<Decoration>('bg', decoration, defaultValue: null));
+      DiagnosticsProperty<Decoration>('bg', decoration, defaultValue: null),
+    );
     // TODO: debug [position]?
   }
 }
@@ -106,17 +111,22 @@ class _AnimatedDecorationBoxState
   @override
   Widget build(BuildContext context) {
     return DecoratedBox(
-      child: widget.child,
-      decoration: _decoration?.evaluate(animation) ?? BoxDecoration(),
+      decoration: _decoration?.evaluate(animation) ?? const BoxDecoration(),
       position: widget.position ?? DecorationPosition.background,
+      child: widget.child,
     );
   }
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder description) {
     super.debugFillProperties(description);
-    description.add(DiagnosticsProperty<DecorationTween>('bg', _decoration,
-        defaultValue: null));
+    description.add(
+      DiagnosticsProperty<DecorationTween>(
+        'bg',
+        _decoration,
+        defaultValue: null,
+      ),
+    );
   }
 }
 
@@ -161,9 +171,14 @@ class _AnimatedConstrainedBox extends ImplicitlyAnimatedWidget {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    properties.add(DiagnosticsProperty<BoxConstraints>(
-        'constraints', constraints,
-        defaultValue: null, showName: false));
+    properties.add(
+      DiagnosticsProperty<BoxConstraints>(
+        'constraints',
+        constraints,
+        defaultValue: null,
+        showName: false,
+      ),
+    );
   }
 }
 
@@ -183,17 +198,22 @@ class _AnimatedConstrainedBoxState
   @override
   Widget build(BuildContext context) {
     return ConstrainedBox(
+      constraints: _constraints?.evaluate(animation) ?? const BoxConstraints(),
       child: widget.child,
-      constraints: _constraints?.evaluate(animation) ?? BoxConstraints(),
     );
   }
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder description) {
     super.debugFillProperties(description);
-    description.add(DiagnosticsProperty<BoxConstraintsTween>(
-        'constraints', _constraints,
-        showName: false, defaultValue: null));
+    description.add(
+      DiagnosticsProperty<BoxConstraintsTween>(
+        'constraints',
+        _constraints,
+        showName: false,
+        defaultValue: null,
+      ),
+    );
   }
 }
 
@@ -201,7 +221,7 @@ class _AnimatedTransform extends ImplicitlyAnimatedWidget {
   /// Creates a container that animates its parameters implicitly.
   ///
   /// The [curve] and [duration] arguments must not be null.
-  _AnimatedTransform({
+  const _AnimatedTransform({
     Key? key,
     this.transform,
     this.origin,
@@ -241,9 +261,14 @@ class _AnimatedTransform extends ImplicitlyAnimatedWidget {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    properties.add(DiagnosticsProperty<AlignmentGeometry>(
-        'alignment', alignment,
-        showName: false, defaultValue: null));
+    properties.add(
+      DiagnosticsProperty<AlignmentGeometry>(
+        'alignment',
+        alignment,
+        showName: false,
+        defaultValue: null,
+      ),
+    );
     properties.add(ObjectFlagProperty<Matrix4>.has('transform', transform));
     // TODO: debug [origin], [transformHitTest]?
   }
@@ -275,20 +300,25 @@ class _AnimatedTransformState
   @override
   Widget build(BuildContext context) {
     return Transform(
-      child: widget.child,
       transform: _transform?.evaluate(animation) ?? Matrix4.zero(),
       alignment: _alignment?.evaluate(animation),
       origin: widget.origin,
       transformHitTests: widget.transformHitTests ?? true,
+      child: widget.child,
     );
   }
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder description) {
     super.debugFillProperties(description);
-    description.add(DiagnosticsProperty<AlignmentGeometryTween>(
-        'alignment', _alignment,
-        showName: false, defaultValue: null));
+    description.add(
+      DiagnosticsProperty<AlignmentGeometryTween>(
+        'alignment',
+        _alignment,
+        showName: false,
+        defaultValue: null,
+      ),
+    );
     description
         .add(ObjectFlagProperty<Matrix4Tween>.has('transform', _transform));
   }
@@ -296,7 +326,7 @@ class _AnimatedTransformState
 
 class _AnimatedClipRRect extends ImplicitlyAnimatedWidget {
   /// The [curve] and [duration] arguments must not be null.
-  _AnimatedClipRRect({
+  const _AnimatedClipRRect({
     Key? key,
     this.topLeft,
     this.topRight,
@@ -334,12 +364,6 @@ class _AnimatedClipRRect extends ImplicitlyAnimatedWidget {
 
   @override
   _AnimatedClipRRectState createState() => _AnimatedClipRRectState();
-
-  @override
-  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
-    //TODO: debug [topLeft], [topRight], [bottomLeft], [bottomRight]
-  }
 }
 
 class _AnimatedClipRRectState
@@ -376,7 +400,6 @@ class _AnimatedClipRRectState
   @override
   Widget build(BuildContext context) {
     return ClipRRect(
-      child: widget.child,
       clipper: widget.clipper,
       clipBehavior: widget.clipBehavior ?? Clip.antiAlias,
       borderRadius: BorderRadius.only(
@@ -393,6 +416,7 @@ class _AnimatedClipRRectState
             ? Radius.circular(_bottomRight!.evaluate(animation))
             : Radius.zero,
       ),
+      child: widget.child,
     );
   }
 
@@ -500,12 +524,6 @@ class _AnimatedOverflowBox extends ImplicitlyAnimatedWidget {
 
   @override
   _AnimatedOverflowBoxState createState() => _AnimatedOverflowBoxState();
-
-  @override
-  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
-    // TODO: debug
-  }
 }
 
 class _AnimatedOverflowBoxState
@@ -538,11 +556,11 @@ class _AnimatedOverflowBoxState
       (dynamic value) => Tween<double>(begin: value as double),
     ) as Tween<double>?;
     _alignment = visitor(
-            _alignment,
-            widget.alignment,
-            (dynamic value) =>
-                AlignmentGeometryTween(begin: value as AlignmentGeometry))
-        as AlignmentGeometryTween;
+      _alignment,
+      widget.alignment,
+      (dynamic value) =>
+          AlignmentGeometryTween(begin: value as AlignmentGeometry),
+    ) as AlignmentGeometryTween?;
   }
 
   @override

--- a/lib/src/extensions/icon_extension.dart
+++ b/lib/src/extensions/icon_extension.dart
@@ -9,14 +9,14 @@ extension StyledIcon<T extends Icon> on T {
   }) =>
       (this is _StyledAnimatedIconContainer
           ? _StyledAnimatedIconContainer(
-              this.icon,
+              icon,
               color: color ?? this.color,
               size: size ?? this.size,
               semanticLabel: semanticLabel ?? this.semanticLabel,
               textDirection: textDirection ?? this.textDirection,
             )
           : Icon(
-              this.icon,
+              icon,
               color: color ?? this.color,
               size: size ?? this.size,
               semanticLabel: semanticLabel ?? this.semanticLabel,

--- a/lib/src/extensions/list_extension.dart
+++ b/lib/src/extensions/list_extension.dart
@@ -65,7 +65,7 @@ extension StyledList<E> on List<Widget> {
         clipBehavior: clipBehavior,
         children: this,
       );
-  
+
   Widget toWrap({
     Key? key,
     Axis direction = Axis.horizontal,

--- a/lib/src/extensions/list_extension.dart
+++ b/lib/src/extensions/list_extension.dart
@@ -19,8 +19,8 @@ extension StyledList<E> on List<Widget> {
         textDirection: textDirection,
         verticalDirection: verticalDirection,
         textBaseline: textBaseline,
-        children: separator != null && this.length > 0
-            ? (this.expand((child) => [child, separator]).toList()
+        children: separator != null && isNotEmpty
+            ? (expand((child) => [child, separator]).toList()
               ..removeLast())
             : this,
       );
@@ -43,8 +43,8 @@ extension StyledList<E> on List<Widget> {
         textDirection: textDirection,
         verticalDirection: verticalDirection,
         textBaseline: textBaseline,
-        children: separator != null && this.length > 0
-            ? (this.expand((child) => [child, separator]).toList()
+        children: separator != null && isNotEmpty
+            ? (expand((child) => [child, separator]).toList()
               ..removeLast())
             : this,
       );

--- a/lib/src/extensions/text_extension.dart
+++ b/lib/src/extensions/text_extension.dart
@@ -46,7 +46,7 @@ extension StyledText<T extends Text> on T {
             )) as T;
 
   T textStyle(TextStyle style) => this.copyWith(
-        style: (this.style ?? TextStyle()).copyWith(
+        style: (this.style ?? const TextStyle()).copyWith(
           background: style.background,
           backgroundColor: style.backgroundColor,
           color: style.color,
@@ -76,43 +76,43 @@ extension StyledText<T extends Text> on T {
       this.copyWith(textScaleFactor: scaleFactor);
 
   T bold() => this.copyWith(
-        style: (this.style ?? TextStyle()).copyWith(
+        style: (style ?? const TextStyle()).copyWith(
           fontWeight: FontWeight.bold,
         ),
       );
 
   T italic() => this.copyWith(
-        style: (this.style ?? TextStyle()).copyWith(
+        style: (style ?? const TextStyle()).copyWith(
           fontStyle: FontStyle.italic,
         ),
       );
 
   T fontWeight(FontWeight? fontWeight) => this.copyWith(
-        style: (this.style ?? TextStyle()).copyWith(
+        style: (style ?? const TextStyle()).copyWith(
           fontWeight: fontWeight,
         ),
       );
 
   T fontSize(double? size) => this.copyWith(
-        style: (this.style ?? TextStyle()).copyWith(
+        style: (style ?? const TextStyle()).copyWith(
           fontSize: size,
         ),
       );
 
   T fontFamily(String? font) => this.copyWith(
-        style: (this.style ?? TextStyle()).copyWith(
+        style: (style ?? const TextStyle()).copyWith(
           fontFamily: font,
         ),
       );
 
   T letterSpacing(double? space) => this.copyWith(
-        style: (this.style ?? TextStyle()).copyWith(
+        style: (style ?? const TextStyle()).copyWith(
           letterSpacing: space,
         ),
       );
 
   T wordSpacing(double? space) => this.copyWith(
-        style: (this.style ?? TextStyle()).copyWith(
+        style: (style ?? const TextStyle()).copyWith(
           wordSpacing: space,
         ),
       );
@@ -123,7 +123,7 @@ extension StyledText<T extends Text> on T {
     Offset offset = Offset.zero,
   }) =>
       this.copyWith(
-        style: (this.style ?? TextStyle()).copyWith(
+        style: (style ?? const TextStyle()).copyWith(
           shadows: [
             Shadow(
               color: color,
@@ -140,15 +140,16 @@ extension StyledText<T extends Text> on T {
     Color color = const Color(0x33000000),
     double opacityRatio = 1.0,
   }) {
-    double calculatedOpacity = _elevationOpacityCurve(elevation) * opacityRatio;
+    final double calculatedOpacity =
+        _elevationOpacityCurve(elevation) * opacityRatio;
 
-    Shadow shadow = Shadow(
+    final Shadow shadow = Shadow(
       color: color.withOpacity(calculatedOpacity),
       blurRadius: elevation,
       offset: Offset(sin(angle) * elevation, cos(angle) * elevation),
     );
     return this.copyWith(
-      style: (this.style ?? TextStyle()).copyWith(
+      style: (style ?? const TextStyle()).copyWith(
         shadows: [
           shadow,
         ],
@@ -157,7 +158,7 @@ extension StyledText<T extends Text> on T {
   }
 
   T textColor(Color? color) => this.copyWith(
-        style: (this.style ?? TextStyle()).copyWith(
+        style: (style ?? const TextStyle()).copyWith(
           color: color,
         ),
       );
@@ -168,7 +169,7 @@ extension StyledText<T extends Text> on T {
       this.copyWith(textDirection: direction);
 
   T textBaseline(TextBaseline? textBaseline) => this.copyWith(
-        style: (this.style ?? TextStyle()).copyWith(
+        style: (style ?? const TextStyle()).copyWith(
           textBaseline: textBaseline,
         ),
       );

--- a/lib/src/extensions/text_span_extension.dart
+++ b/lib/src/extensions/text_span_extension.dart
@@ -7,8 +7,8 @@ extension StyledTextSpan<T extends TextSpan> on T {
     String? semanticsLabel,
   }) =>
       TextSpan(
-        text: this.text,
-        children: this.children,
+        text: text,
+        children: children,
         style: style ?? this.style,
         recognizer: recognizer ?? this.recognizer,
         semanticsLabel: semanticsLabel ?? this.semanticsLabel,
@@ -42,43 +42,43 @@ extension StyledTextSpan<T extends TextSpan> on T {
       );
 
   T bold() => this.copyWith(
-        style: (this.style ?? TextStyle()).copyWith(
+        style: (style ?? const TextStyle()).copyWith(
           fontWeight: FontWeight.bold,
         ),
       );
 
   T italic() => this.copyWith(
-        style: (this.style ?? TextStyle()).copyWith(
+        style: (style ?? const TextStyle()).copyWith(
           fontStyle: FontStyle.italic,
         ),
       );
 
   T fontWeight(FontWeight fontWeight) => this.copyWith(
-        style: (this.style ?? TextStyle()).copyWith(
+        style: (style ?? const TextStyle()).copyWith(
           fontWeight: fontWeight,
         ),
       );
 
   T fontSize(double size) => this.copyWith(
-        style: (this.style ?? TextStyle()).copyWith(
+        style: (style ?? const TextStyle()).copyWith(
           fontSize: size,
         ),
       );
 
   T fontFamily(String font) => this.copyWith(
-        style: (this.style ?? TextStyle()).copyWith(
+        style: (style ?? const TextStyle()).copyWith(
           fontFamily: font,
         ),
       );
 
   T letterSpacing(double space) => this.copyWith(
-        style: (this.style ?? TextStyle()).copyWith(
+        style: (style ?? const TextStyle()).copyWith(
           letterSpacing: space,
         ),
       );
 
   T wordSpacing(double space) => this.copyWith(
-        style: (this.style ?? TextStyle()).copyWith(
+        style: (style ?? const TextStyle()).copyWith(
           wordSpacing: space,
         ),
       );
@@ -89,7 +89,7 @@ extension StyledTextSpan<T extends TextSpan> on T {
     Offset offset = Offset.zero,
   }) =>
       this.copyWith(
-        style: (this.style ?? TextStyle()).copyWith(
+        style: (style ?? const TextStyle()).copyWith(
           shadows: [
             Shadow(
               color: color,
@@ -109,15 +109,16 @@ extension StyledTextSpan<T extends TextSpan> on T {
     Color color = const Color(0x33000000),
     double opacityRatio = 1.0,
   }) {
-    double calculatedOpacity = _elevationOpacityCurve(elevation) * opacityRatio;
+    final double calculatedOpacity =
+        _elevationOpacityCurve(elevation) * opacityRatio;
 
-    Shadow shadow = Shadow(
+    final Shadow shadow = Shadow(
       color: color.withOpacity(calculatedOpacity),
       blurRadius: elevation,
       offset: Offset(sin(angle) * elevation, cos(angle) * elevation),
     );
     return this.copyWith(
-      style: (this.style ?? TextStyle()).copyWith(
+      style: (style ?? const TextStyle()).copyWith(
         shadows: [
           shadow,
         ],
@@ -126,13 +127,13 @@ extension StyledTextSpan<T extends TextSpan> on T {
   }
 
   T textColor(Color color) => this.copyWith(
-        style: (this.style ?? TextStyle()).copyWith(
+        style: (style ?? const TextStyle()).copyWith(
           color: color,
         ),
       );
 
   T textBaseline(TextBaseline textBaseline) => this.copyWith(
-        style: (this.style ?? TextStyle()).copyWith(
+        style: (style ?? const TextStyle()).copyWith(
           textBaseline: textBaseline,
         ),
       );

--- a/lib/src/extensions/widget_extension.dart
+++ b/lib/src/extensions/widget_extension.dart
@@ -4,10 +4,12 @@ typedef GestureOnTapChangeCallback = void Function(bool tapState);
 
 extension StyledWidget on Widget {
   _StyledAnimatedModel _getAnimation(BuildContext context) {
-    _StyledAnimatedModel? animation =
+    final _StyledAnimatedModel? animation =
         _StyledInheritedAnimation.of(context)?.animation;
-    assert(animation != null,
-        '[styled_widget]: You can`t animate without defining the animation. Call the method animate() higher in your widget hierarchy to define an animation');
+    assert(
+      animation != null,
+      '[styled_widget]: You can`t animate without defining the animation. Call the method animate() higher in your widget hierarchy to define an animation',
+    );
     return animation!;
   }
 
@@ -52,9 +54,8 @@ extension StyledWidget on Widget {
           ? Builder(
               key: key,
               builder: (BuildContext context) {
-                _StyledAnimatedModel animation = this._getAnimation(context);
+                final _StyledAnimatedModel animation = _getAnimation(context);
                 return AnimatedPadding(
-                  child: this,
                   padding: EdgeInsets.only(
                     top: top ?? vertical ?? all ?? 0.0,
                     bottom: bottom ?? vertical ?? all ?? 0.0,
@@ -63,6 +64,7 @@ extension StyledWidget on Widget {
                   ),
                   duration: animation.duration,
                   curve: animation.curve,
+                  child: this,
                 );
               },
             )
@@ -92,9 +94,8 @@ extension StyledWidget on Widget {
           ? Builder(
               key: key,
               builder: (BuildContext context) {
-                _StyledAnimatedModel animation = this._getAnimation(context);
+                final _StyledAnimatedModel animation = _getAnimation(context);
                 return AnimatedPadding(
-                  child: this,
                   padding: EdgeInsetsDirectional.only(
                     top: top ?? vertical ?? all ?? 0.0,
                     bottom: bottom ?? vertical ?? all ?? 0.0,
@@ -103,6 +104,7 @@ extension StyledWidget on Widget {
                   ),
                   duration: animation.duration,
                   curve: animation.curve,
+                  child: this,
                 );
               },
             )
@@ -128,13 +130,14 @@ extension StyledWidget on Widget {
               key: key,
               builder: (animation) {
                 return AnimatedOpacity(
-                  child: this,
                   opacity: opacity,
                   alwaysIncludeSemantics: alwaysIncludeSemantics,
                   duration: animation.duration,
                   curve: animation.curve,
+                  child: this,
                 );
-              })
+              },
+            )
           : Opacity(
               key: key,
               opacity: opacity,
@@ -161,12 +164,12 @@ extension StyledWidget on Widget {
           ? Builder(
               key: key,
               builder: (BuildContext context) {
-                _StyledAnimatedModel animation = this._getAnimation(context);
+                final _StyledAnimatedModel animation = _getAnimation(context);
                 return AnimatedAlign(
-                  child: this,
                   alignment: alignment,
                   duration: animation.duration,
                   curve: animation.curve,
+                  child: this,
                 );
               },
             )
@@ -186,17 +189,17 @@ extension StyledWidget on Widget {
               key: key,
               builder: (animation) {
                 return _AnimatedDecorationBox(
-                  child: this,
                   decoration: BoxDecoration(color: color),
                   duration: animation.duration,
                   curve: animation.curve,
+                  child: this,
                 );
               },
             )
           : DecoratedBox(
               key: key,
-              child: this,
               decoration: BoxDecoration(color: color),
+              child: this,
             );
 
   Widget backgroundImage(
@@ -209,17 +212,17 @@ extension StyledWidget on Widget {
               key: key,
               builder: (animation) {
                 return _AnimatedDecorationBox(
-                  child: this,
                   decoration: BoxDecoration(image: image),
                   duration: animation.duration,
                   curve: animation.curve,
+                  child: this,
                 );
               },
             )
           : DecoratedBox(
               key: key,
-              child: this,
               decoration: BoxDecoration(image: image),
+              child: this,
             );
 
   Widget backgroundGradient(
@@ -232,17 +235,17 @@ extension StyledWidget on Widget {
               key: key,
               builder: (animation) {
                 return _AnimatedDecorationBox(
-                  child: this,
                   decoration: BoxDecoration(gradient: gradient),
                   duration: animation.duration,
                   curve: animation.curve,
+                  child: this,
                 );
               },
             )
           : DecoratedBox(
               key: key,
-              child: this,
               decoration: BoxDecoration(gradient: gradient),
+              child: this,
             );
 
   Widget backgroundLinearGradient({
@@ -255,7 +258,7 @@ extension StyledWidget on Widget {
     GradientTransform? transform,
     bool animate = false,
   }) {
-    BoxDecoration decoration = BoxDecoration(
+    final BoxDecoration decoration = BoxDecoration(
       gradient: LinearGradient(
         begin: begin,
         end: end,
@@ -270,17 +273,17 @@ extension StyledWidget on Widget {
             key: key,
             builder: (animation) {
               return _AnimatedDecorationBox(
-                child: this,
                 decoration: decoration,
                 duration: animation.duration,
                 curve: animation.curve,
+                child: this,
               );
             },
           )
         : DecoratedBox(
             key: key,
-            child: this,
             decoration: decoration,
+            child: this,
           );
   }
 
@@ -296,7 +299,7 @@ extension StyledWidget on Widget {
     GradientTransform? transform,
     bool animate = false,
   }) {
-    BoxDecoration decoration = BoxDecoration(
+    final BoxDecoration decoration = BoxDecoration(
       gradient: RadialGradient(
         center: center,
         radius: radius,
@@ -313,17 +316,17 @@ extension StyledWidget on Widget {
             key: key,
             builder: (animation) {
               return _AnimatedDecorationBox(
-                child: this,
                 decoration: decoration,
                 duration: animation.duration,
                 curve: animation.curve,
+                child: this,
               );
             },
           )
         : DecoratedBox(
             key: key,
-            child: this,
             decoration: decoration,
+            child: this,
           );
   }
 
@@ -338,7 +341,7 @@ extension StyledWidget on Widget {
     GradientTransform? transform,
     bool animate = false,
   }) {
-    BoxDecoration decoration = BoxDecoration(
+    final BoxDecoration decoration = BoxDecoration(
       gradient: SweepGradient(
         center: center,
         startAngle: startAngle,
@@ -354,17 +357,17 @@ extension StyledWidget on Widget {
             key: key,
             builder: (animation) {
               return _AnimatedDecorationBox(
-                child: this,
                 decoration: decoration,
                 duration: animation.duration,
                 curve: animation.curve,
+                child: this,
               );
             },
           )
         : DecoratedBox(
             key: key,
-            child: this,
             decoration: decoration,
+            child: this,
           );
   }
 
@@ -378,17 +381,17 @@ extension StyledWidget on Widget {
               key: key,
               builder: (animation) {
                 return _AnimatedDecorationBox(
-                  child: this,
                   decoration: BoxDecoration(backgroundBlendMode: blendMode),
                   duration: animation.duration,
                   curve: animation.curve,
+                  child: this,
                 );
               },
             )
           : DecoratedBox(
               key: key,
-              child: this,
               decoration: BoxDecoration(backgroundBlendMode: blendMode),
+              child: this,
             );
 
   Widget backgroundBlur(
@@ -401,10 +404,10 @@ extension StyledWidget on Widget {
               key: key,
               builder: (animation) {
                 return _AnimatedBackgroundBlur(
-                  child: this,
                   sigma: sigma,
                   duration: animation.duration,
                   curve: animation.curve,
+                  child: this,
                 );
               },
             )
@@ -426,7 +429,7 @@ extension StyledWidget on Widget {
     double? bottomRight,
     bool animate = false,
   }) {
-    BoxDecoration decoration = BoxDecoration(
+    final BoxDecoration decoration = BoxDecoration(
       borderRadius: BorderRadius.only(
         topLeft: Radius.circular(topLeft ?? all ?? 0.0),
         topRight: Radius.circular(topRight ?? all ?? 0.0),
@@ -439,17 +442,17 @@ extension StyledWidget on Widget {
             key: key,
             builder: (animation) {
               return _AnimatedDecorationBox(
-                child: this,
                 decoration: decoration,
                 duration: animation.duration,
                 curve: animation.curve,
+                child: this,
               );
             },
           )
         : DecoratedBox(
             key: key,
-            child: this,
             decoration: decoration,
+            child: this,
           );
   }
 
@@ -462,7 +465,7 @@ extension StyledWidget on Widget {
     double? bottomEnd,
     bool animate = false,
   }) {
-    BoxDecoration decoration = BoxDecoration(
+    final BoxDecoration decoration = BoxDecoration(
       borderRadius: BorderRadiusDirectional.only(
         topStart: Radius.circular(topStart ?? all ?? 0.0),
         topEnd: Radius.circular(topEnd ?? all ?? 0.0),
@@ -475,17 +478,17 @@ extension StyledWidget on Widget {
             key: key,
             builder: (animation) {
               return _AnimatedDecorationBox(
-                child: this,
                 decoration: decoration,
                 duration: animation.duration,
                 curve: animation.curve,
+                child: this,
               );
             },
           )
         : DecoratedBox(
             key: key,
-            child: this,
             decoration: decoration,
+            child: this,
           );
   }
 
@@ -505,7 +508,6 @@ extension StyledWidget on Widget {
               key: key,
               builder: (animation) {
                 return _AnimatedClipRRect(
-                  child: this,
                   clipper: clipper,
                   clipBehavior: clipBehavior,
                   topLeft: topLeft ?? all ?? 0.0,
@@ -514,13 +516,13 @@ extension StyledWidget on Widget {
                   bottomRight: bottomRight ?? all ?? 0.0,
                   duration: animation.duration,
                   curve: animation.curve,
+                  child: this,
                 );
               },
             )
           : ClipRRect(
               key: key,
-              child: this,
-              clipper: clipper ?? null,
+              clipper: clipper,
               clipBehavior: clipBehavior,
               borderRadius: BorderRadius.only(
                 topLeft: Radius.circular(topLeft ?? all ?? 0.0),
@@ -528,6 +530,7 @@ extension StyledWidget on Widget {
                 bottomLeft: Radius.circular(bottomLeft ?? all ?? 0.0),
                 bottomRight: Radius.circular(bottomRight ?? all ?? 0.0),
               ),
+              child: this,
             );
 
   Widget clipRect({
@@ -558,7 +561,7 @@ extension StyledWidget on Widget {
     BorderStyle style = BorderStyle.solid,
     bool animate = false,
   }) {
-    BoxDecoration decoration = BoxDecoration(
+    final BoxDecoration decoration = BoxDecoration(
       border: Border(
         left: (left ?? all) == null
             ? BorderSide.none
@@ -579,17 +582,17 @@ extension StyledWidget on Widget {
             key: key,
             builder: (animation) {
               return _AnimatedDecorationBox(
-                child: this,
                 decoration: decoration,
                 duration: animation.duration,
                 curve: animation.curve,
+                child: this,
               );
             },
           )
         : DecoratedBox(
             key: key,
-            child: this,
             decoration: decoration,
+            child: this,
           );
   }
 
@@ -606,7 +609,7 @@ extension StyledWidget on Widget {
     DecorationPosition position = DecorationPosition.background,
     bool animate = false,
   }) {
-    BoxDecoration decoration = BoxDecoration(
+    final BoxDecoration decoration = BoxDecoration(
       color: color,
       image: image,
       border: border,
@@ -621,19 +624,19 @@ extension StyledWidget on Widget {
             key: key,
             builder: (animation) {
               return _AnimatedDecorationBox(
-                child: this,
                 decoration: decoration,
                 position: position,
                 duration: animation.duration,
                 curve: animation.curve,
+                child: this,
               );
             },
           )
         : DecoratedBox(
             key: key,
-            child: this,
             decoration: decoration,
             position: position,
+            child: this,
           );
   }
 
@@ -649,11 +652,11 @@ extension StyledWidget on Widget {
   }) =>
       Material(
         key: key,
-        child: this,
         color: Colors.transparent,
         elevation: elevation,
         borderRadius: borderRadius,
         shadowColor: shadowColor,
+        child: this,
       );
 
   Widget neumorphism({
@@ -664,17 +667,19 @@ extension StyledWidget on Widget {
     double curve = 0.0,
     bool animate = false,
   }) {
-    double offset = elevation / 2;
-    int colorOffset = (40 * curve).toInt();
-    final int Function(int, int) adjustColor = (int color, int colorOffset) {
-      int colorVal = color + colorOffset;
-      if (colorVal > 255)
+    final double offset = elevation / 2;
+    final int colorOffset = (40 * curve).toInt();
+    int adjustColor(int color, int colorOffset) {
+      final int colorVal = color + colorOffset;
+      if (colorVal > 255) {
         return 255;
-      else if (colorVal < 0) return 0;
+      } else if (colorVal < 0) {
+        return 0;
+      }
       return colorVal;
-    };
+    }
 
-    BoxDecoration decoration = BoxDecoration(
+    final BoxDecoration decoration = BoxDecoration(
       gradient: LinearGradient(
         begin: Alignment.topLeft,
         end: Alignment.bottomRight,
@@ -702,7 +707,7 @@ extension StyledWidget on Widget {
           offset: Offset(-offset, -offset),
         ),
         BoxShadow(
-          color: Color(0xAAA3B1C6),
+          color: const Color(0xAAA3B1C6),
           blurRadius: elevation.abs(),
           offset: Offset(offset, offset),
         ),
@@ -714,17 +719,17 @@ extension StyledWidget on Widget {
             key: key,
             builder: (animation) {
               return _AnimatedDecorationBox(
-                child: this,
                 decoration: decoration,
                 duration: animation.duration,
                 curve: animation.curve,
+                child: this,
               );
             },
           )
         : DecoratedBox(
             key: key,
-            child: this,
             decoration: decoration,
+            child: this,
           );
   }
 
@@ -736,7 +741,7 @@ extension StyledWidget on Widget {
     double spreadRadius = 0.0,
     bool animate = false,
   }) {
-    BoxDecoration decoration = BoxDecoration(
+    final BoxDecoration decoration = BoxDecoration(
       boxShadow: [
         BoxShadow(
           color: color,
@@ -751,17 +756,17 @@ extension StyledWidget on Widget {
             key: key,
             builder: (animation) {
               return _AnimatedDecorationBox(
-                child: this,
                 decoration: decoration,
                 duration: animation.duration,
                 curve: animation.curve,
+                child: this,
               );
             },
           )
         : DecoratedBox(
             key: key,
-            child: this,
             decoration: decoration,
+            child: this,
           );
   }
 
@@ -789,17 +794,17 @@ extension StyledWidget on Widget {
             key: key,
             builder: (animation) {
               return _AnimatedConstrainedBox(
-                child: this,
                 constraints: constraints,
                 duration: animation.duration,
                 curve: animation.curve,
+                child: this,
               );
             },
           )
         : ConstrainedBox(
             key: key,
-            child: this,
             constraints: constraints,
+            child: this,
           );
   }
 
@@ -813,17 +818,17 @@ extension StyledWidget on Widget {
               key: key,
               builder: (animation) {
                 return _AnimatedConstrainedBox(
-                  child: this,
                   constraints: BoxConstraints.tightFor(width: width),
                   duration: animation.duration,
                   curve: animation.curve,
+                  child: this,
                 );
               },
             )
           : ConstrainedBox(
               key: key,
-              child: this,
               constraints: BoxConstraints.tightFor(width: width),
+              child: this,
             );
 
   Widget height(
@@ -836,17 +841,17 @@ extension StyledWidget on Widget {
               key: key,
               builder: (animation) {
                 return _AnimatedConstrainedBox(
-                  child: this,
                   constraints: BoxConstraints.tightFor(height: height),
                   duration: animation.duration,
                   curve: animation.curve,
+                  child: this,
                 );
               },
             )
           : ConstrainedBox(
               key: key,
-              child: this,
               constraints: BoxConstraints.tightFor(height: height),
+              child: this,
             );
 
   // TODO: FEATURE: ripple animation
@@ -871,7 +876,7 @@ extension StyledWidget on Widget {
               key: key,
               builder: (BuildContext context) {
                 // TODO: PERFORMANCE: findAncestorWidgetOfExactType vs InheritedWidget performance
-                GestureDetector? gestures =
+                final GestureDetector? gestures =
                     context.findAncestorWidgetOfExactType<GestureDetector>();
                 return Material(
                   color: Colors.transparent,
@@ -913,23 +918,23 @@ extension StyledWidget on Widget {
               key: key,
               builder: (animation) {
                 return _AnimatedTransform(
-                  child: this,
                   transform: Matrix4.rotationZ(angle),
                   alignment: alignment,
                   origin: origin,
                   transformHitTests: transformHitTests,
                   duration: animation.duration,
                   curve: animation.curve,
+                  child: this,
                 );
               },
             )
           : Transform.rotate(
               key: key,
-              child: this,
               angle: angle,
               alignment: alignment,
               origin: origin,
               transformHitTests: transformHitTests,
+              child: this,
             );
 
   Widget scale({
@@ -947,13 +952,16 @@ extension StyledWidget on Widget {
               key: key,
               builder: (animation) {
                 return _AnimatedTransform(
-                  child: this,
                   transform: Matrix4.diagonal3Values(
-                      x ?? all ?? 0, y ?? all ?? 0, 1.0),
+                    x ?? all ?? 0,
+                    y ?? all ?? 0,
+                    1.0,
+                  ),
                   alignment: alignment,
                   transformHitTests: transformHitTests,
                   duration: animation.duration,
                   curve: animation.curve,
+                  child: this,
                 );
               },
             )
@@ -962,9 +970,9 @@ extension StyledWidget on Widget {
               transform:
                   Matrix4.diagonal3Values(x ?? all ?? 0, y ?? all ?? 0, 1.0),
               alignment: alignment,
-              child: this,
               origin: origin,
               transformHitTests: transformHitTests,
+              child: this,
             );
 
   Widget translate({
@@ -978,12 +986,12 @@ extension StyledWidget on Widget {
               key: key,
               builder: (animation) {
                 return _AnimatedTransform(
-                  child: this,
                   transform:
                       Matrix4.translationValues(offset.dx, offset.dy, 0.0),
                   transformHitTests: transformHitTests,
                   duration: animation.duration,
                   curve: animation.curve,
+                  child: this,
                 );
               },
             )
@@ -1007,13 +1015,13 @@ extension StyledWidget on Widget {
               key: key,
               builder: (animation) {
                 return _AnimatedTransform(
-                  child: this,
                   transform: transform,
                   origin: origin,
                   alignment: alignment,
                   transformHitTests: transformHitTests,
                   duration: animation.duration,
                   curve: animation.curve,
+                  child: this,
                 );
               },
             )
@@ -1040,7 +1048,6 @@ extension StyledWidget on Widget {
               key: key,
               builder: (animation) {
                 return _AnimatedOverflowBox(
-                  child: this,
                   alignment: alignment,
                   minWidth: minWidth,
                   maxWidth: minWidth,
@@ -1048,6 +1055,7 @@ extension StyledWidget on Widget {
                   maxHeight: maxHeight,
                   duration: animation.duration,
                   curve: animation.curve,
+                  child: this,
                 );
               },
             )
@@ -1073,7 +1081,6 @@ extension StyledWidget on Widget {
   }) =>
       SingleChildScrollView(
         key: key,
-        child: this,
         scrollDirection: scrollDirection,
         reverse: reverse,
         primary: primary,
@@ -1081,6 +1088,7 @@ extension StyledWidget on Widget {
         controller: controller,
         dragStartBehavior: dragStartBehavior,
         padding: padding,
+        child: this,
       );
 
   Widget expanded({
@@ -1089,8 +1097,8 @@ extension StyledWidget on Widget {
   }) =>
       Expanded(
         key: key,
-        child: this,
         flex: flex,
+        child: this,
       );
 
   Widget flexible({
@@ -1100,9 +1108,9 @@ extension StyledWidget on Widget {
   }) =>
       Flexible(
         key: key,
-        child: this,
         flex: flex,
         fit: fit,
+        child: this,
       );
 
   Widget positioned({
@@ -1120,7 +1128,6 @@ extension StyledWidget on Widget {
               key: key,
               builder: (animation) {
                 return AnimatedPositioned(
-                  child: this,
                   duration: animation.duration,
                   curve: animation.curve,
                   left: left,
@@ -1129,18 +1136,19 @@ extension StyledWidget on Widget {
                   bottom: bottom,
                   width: width,
                   height: height,
+                  child: this,
                 );
               },
             )
           : Positioned(
               key: key,
-              child: this,
               left: left,
               top: top,
               right: right,
               bottom: bottom,
               width: width,
               height: height,
+              child: this,
             );
 
   Widget positionedDirectional({
@@ -1158,7 +1166,6 @@ extension StyledWidget on Widget {
               key: key,
               builder: (animation) {
                 return AnimatedPositionedDirectional(
-                  child: this,
                   duration: animation.duration,
                   curve: animation.curve,
                   start: start,
@@ -1167,18 +1174,19 @@ extension StyledWidget on Widget {
                   bottom: bottom,
                   width: width,
                   height: height,
+                  child: this,
                 );
               },
             )
           : PositionedDirectional(
               key: key,
-              child: this,
               start: start,
               end: end,
               top: top,
               bottom: bottom,
               width: width,
               height: height,
+              child: this,
             );
 
   Widget safeArea({

--- a/lib/styled_widget.dart
+++ b/lib/styled_widget.dart
@@ -3,19 +3,17 @@ library styled_widget;
 import 'dart:math';
 import 'dart:ui';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
-import 'package:flutter/foundation.dart';
-
-part 'src/extensions/widget_extension.dart';
-part 'src/extensions/text_extension.dart';
-part 'src/extensions/text_span_extension.dart';
-part 'src/extensions/list_extension.dart';
-part 'src/extensions/icon_extension.dart';
-
-part 'src/animated_widget.dart';
-part 'src/animated_text.dart';
-part 'src/animated_icon.dart';
 
 part 'src/Styled.dart';
+part 'src/animated_icon.dart';
+part 'src/animated_text.dart';
+part 'src/animated_widget.dart';
+part 'src/extensions/icon_extension.dart';
+part 'src/extensions/list_extension.dart';
+part 'src/extensions/text_extension.dart';
+part 'src/extensions/text_span_extension.dart';
+part 'src/extensions/widget_extension.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,4 +15,4 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  lint: ^1.10.0
+  lint: ^2.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,8 +10,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  lint: ^1.5.3
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
+
+  lint: ^1.10.0


### PR DESCRIPTION
Fixes #79

There are a lot of lint errors reported by `flutter analyze` (not introduced by this PR, this is already the case on `master`)
Should we also run ~~`flutter format` and perhaps~~ `dart fix`? I have run `flutter format` to fix Dart formatter reports.

This PR should fix Pass static analytics and Support up-to-date dependencies as reported by https://pub.dev/packages/styled_widget/score